### PR TITLE
[FEAT] ImagePickerView-NavigationBar 작업 #37

### DIFF
--- a/DaangnMarket/DaangnMarket/Scene/ImagePicker/ImagePickerViewController.storyboard
+++ b/DaangnMarket/DaangnMarket/Scene/ImagePicker/ImagePickerViewController.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -18,7 +18,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UwV-h4-crk">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UwV-h4-crk" customClass="DaangnNaviBar" customModule="DaangnMarket" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="44" width="414" height="40"/>
                                 <color key="backgroundColor" name="daangnWhite"/>
                                 <constraints>
@@ -60,6 +60,7 @@
                     </view>
                     <connections>
                         <outlet property="imageCollectionView" destination="yKh-HL-Yb3" id="gKf-0e-Dnl"/>
+                        <outlet property="navigationBarView" destination="UwV-h4-crk" id="cR6-Xo-zbp"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/DaangnMarket/DaangnMarket/Scene/ImagePicker/ImagePickerViewController.swift
+++ b/DaangnMarket/DaangnMarket/Scene/ImagePicker/ImagePickerViewController.swift
@@ -94,7 +94,7 @@ extension ImagePickerViewController: UICollectionViewDataSource {
         
         cell.delegate = self
         cell.index = indexPath.row
-        cell.configureCell(images[indexPath.row]) //TODO: - 사진을 받아올 때 수정할 예정
+        cell.configureCell(images[indexPath.row])
         
         return cell
     }
@@ -128,7 +128,6 @@ extension ImagePickerViewController: ImageCollectionViewCellDelegate {
         } else {
             let image = images[cell.index].image
             selectedImages.append(image)
-            print("\(222)")
             images[cell.index].selectedNumber = selectedImages.count
         }
         imageCollectionView.reloadData()

--- a/DaangnMarket/DaangnMarket/Scene/ImagePicker/ImagePickerViewController.swift
+++ b/DaangnMarket/DaangnMarket/Scene/ImagePicker/ImagePickerViewController.swift
@@ -13,7 +13,22 @@ class ImagePickerViewController: UIViewController {
     @IBOutlet weak var imageCollectionView: UICollectionView!
     @IBOutlet weak var navigationBarView: UIView!
     
-    var selectedImages: [UIImage] = []
+    var selectedImages: [UIImage] = []{
+        didSet{
+            guard let daangnNaviBar = navigationBarView.subviews.first as? DaangnNaviBar else {return}
+            
+            if selectedImages.count > 0 {
+                let mutableAttributedString = NSMutableAttributedString()
+                    .setColor(string: "\(selectedImages.count)", to: .daangnOrange)
+                    .setColor(string: " 확인", to: .daangnBlack)
+                daangnNaviBar.doneButton.setAttributedTitle(mutableAttributedString, for: .normal)
+                
+                daangnNaviBar.doneButton.isEnabled = true
+                return
+            }
+            daangnNaviBar.doneButton.isEnabled = false
+        }
+    }
     var images: [ImageData] = []
     
     let imageViewPicker = UIImagePickerController()
@@ -43,7 +58,7 @@ class ImagePickerViewController: UIViewController {
         
         let daangnNaviBar = DaangnNaviBar.createMyClassView()
         daangnNaviBar.naviBarTitleLabel.text = "최근 항목"
-        daangnNaviBar.doneButton.setTitle("확인", for: .normal)
+        daangnNaviBar.doneButton.setAttributedTitle(NSAttributedString(string: "확인"), for: .disabled)
         daangnNaviBar.doneButton.isEnabled = false
         
         navigationBarView.addSubview(daangnNaviBar)
@@ -113,6 +128,7 @@ extension ImagePickerViewController: ImageCollectionViewCellDelegate {
         } else {
             let image = images[cell.index].image
             selectedImages.append(image)
+            print("\(222)")
             images[cell.index].selectedNumber = selectedImages.count
         }
         imageCollectionView.reloadData()

--- a/DaangnMarket/DaangnMarket/Scene/ImagePicker/ImagePickerViewController.swift
+++ b/DaangnMarket/DaangnMarket/Scene/ImagePicker/ImagePickerViewController.swift
@@ -11,6 +11,7 @@ import Photos
 
 class ImagePickerViewController: UIViewController {
     @IBOutlet weak var imageCollectionView: UICollectionView!
+    @IBOutlet weak var navigationBarView: UIView!
     
     var selectedImages: [UIImage] = []
     var images: [ImageData] = []
@@ -22,6 +23,7 @@ class ImagePickerViewController: UIViewController {
         
         configureCollectionView()
         requestAccessPhotoLibrary()
+        configureNavigationBarView()
     }
     
     private func configureCollectionView(){
@@ -34,6 +36,17 @@ class ImagePickerViewController: UIViewController {
         self.imageCollectionView.delegate = self
         
         self.imageViewPicker.delegate = self
+    }
+    
+    private func configureNavigationBarView(){
+        self.navigationController?.isNavigationBarHidden = true
+        
+        let daangnNaviBar = DaangnNaviBar.createMyClassView()
+        daangnNaviBar.naviBarTitleLabel.text = "최근 항목"
+        daangnNaviBar.doneButton.setTitle("확인", for: .normal)
+        daangnNaviBar.doneButton.isEnabled = false
+        
+        navigationBarView.addSubview(daangnNaviBar)
     }
 }
 


### PR DESCRIPTION
## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

상단 바 설정

-  상단 바 UI 구성
- 선택된 사진이 없을 시 '확인'버튼 비활성화
- 선택된 사진 개수 표시

## 🌱 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 지현이가 만든 NSMutableAttributedString 메서드로 선택된 사진 개수 title을 설정해줬습니다~
- enable 상태로 확인 버튼의 title을 구분해줬습니다~

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|  상단 바와 사진 선택  |
| :-------------: |
| ![Simulator Screen Recording - iPhone 11 - 2022-05-22 at 20 44 49](https://user-images.githubusercontent.com/65601189/169693518-3be40abf-965a-4dbb-8754-f3b5fac3b3d6.gif) |

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #37
