### PR TITLE
[FEAT] ImagePickerView-PassImage 작업

### DIFF
--- a/DaangnMarket/DaangnMarket.xcodeproj/project.pbxproj
+++ b/DaangnMarket/DaangnMarket.xcodeproj/project.pbxproj
@@ -350,7 +350,7 @@
 				B85E9D082836527300B81D36 /* CameraButtonCollectionViewCell.swift in Sources */,
 				1434AC3C2833A3B400B053E1 /* ImageCollectionViewCell.swift in Sources */,
 				B83565592838A95D0052DD91 /* DaangnNaviBar.swift in Sources */,
-				1434AC422833FBD900B053E1 /* SampleData.swift in Sources */,
+				1434AC422833FBD900B053E1 /* ImageData.swift in Sources */,
 				1434AC422833FBD900B053E1 /* ImageData.swift in Sources */,
 				B81438E02833ED4E004EA0D9 /* CALayer+.swift in Sources */,
 				B85E9D032835E77E00B81D36 /* SelectedImageCollectionViewCell.swift in Sources */,

--- a/DaangnMarket/DaangnMarket/Scene/Extension/ImagePickerViewController+.swift
+++ b/DaangnMarket/DaangnMarket/Scene/Extension/ImagePickerViewController+.swift
@@ -23,7 +23,9 @@ extension ImagePickerViewController: UIImagePickerControllerDelegate, UINavigati
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
             UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
+            
             selectedImages.append(image)
+            NotificationCenter.default.post(name: Notification.Name("DidTakeAPictureNotification"), object: nil)
         }
         dismiss(animated: true)
     }

--- a/DaangnMarket/DaangnMarket/Scene/ImagePicker/ImagePickerViewController.swift
+++ b/DaangnMarket/DaangnMarket/Scene/ImagePicker/ImagePickerViewController.swift
@@ -64,6 +64,12 @@ class ImagePickerViewController: UIViewController {
         daangnNaviBar.dismissButtonAction = {
             self.dismiss(animated: true)
         }
+        daangnNaviBar.doneButtonAction = {
+            guard let writingViewController = self.presentingViewController as? WritingViewController else {return}
+            writingViewController.selectedImage = self.selectedImages
+            
+            self.dismiss(animated: true)
+        }
         daangnNaviBar.setUp()
         
         navigationBarView.addSubview(daangnNaviBar)

--- a/DaangnMarket/DaangnMarket/Scene/ImagePicker/ImagePickerViewController.swift
+++ b/DaangnMarket/DaangnMarket/Scene/ImagePicker/ImagePickerViewController.swift
@@ -61,6 +61,11 @@ class ImagePickerViewController: UIViewController {
         daangnNaviBar.doneButton.setAttributedTitle(NSAttributedString(string: "확인"), for: .disabled)
         daangnNaviBar.doneButton.isEnabled = false
         
+        daangnNaviBar.dismissButtonAction = {
+            self.dismiss(animated: true)
+        }
+        daangnNaviBar.setUp()
+        
         navigationBarView.addSubview(daangnNaviBar)
     }
 }

--- a/DaangnMarket/DaangnMarket/Scene/ImagePicker/ImagePickerViewController.swift
+++ b/DaangnMarket/DaangnMarket/Scene/ImagePicker/ImagePickerViewController.swift
@@ -39,6 +39,7 @@ class ImagePickerViewController: UIViewController {
         configureCollectionView()
         requestAccessPhotoLibrary()
         configureNavigationBarView()
+        addNotificationObserver()
     }
     
     private func configureCollectionView(){
@@ -73,6 +74,24 @@ class ImagePickerViewController: UIViewController {
         daangnNaviBar.setUp()
         
         navigationBarView.addSubview(daangnNaviBar)
+    }
+    
+    private func addNotificationObserver() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(didTakeAPicture),
+                                               name: Notification.Name("DidTakeAPictureNotification"),
+                                               object: nil)
+    }
+    
+    //MARK: - @objc Method
+    @objc private func didTakeAPicture(){
+        guard let daangnNaviBar = navigationBarView.subviews.first as? DaangnNaviBar else {return}
+        daangnNaviBar.doneButton.sendActions(for: .touchUpInside)
+        
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 }
 


### PR DESCRIPTION
## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
버튼 클릭 시 선택된 사진을 글작성 화면으로 전달한다.

- 취소 버튼 클릭 시 글작성 화면으로 전환
- 확인 버튼 클릭 시 선택된 데이터를 글작성 화면으로 전달하며 화면 전환
- 카메라 촬영 후 즉시 글작성 화면으로 사진 전달

## 🌱 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- notification을 사용해 카메라 촬영 시 확인 버튼에 touchUpInside 이벤트가 발생하도록 구현했습니다!

🥲 혹시 실수하지 않을까 해서 사진첩에서 사진을 불러오는 걸 동기처리로 했더니 엄청엄청 느리네요,, YB는 운다 엉엉
🥲 화면 전환, 사진 불러오기 등이 잘 안 된다? -> 오류가 아니라 사진을 가져오는 중!
🥲 작업을 비동기로 수정해서 해결하도록 하겠습니다..! 
🙇🏻‍♀️혹시 비동기 처리 시 주의해야할 점이 있다면 코드리뷰와 함께 같이 알려주세요🙇🏻‍♀️

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

| 취소 버튼 |   확인 버튼   | 카메라 촬영 |
| :----------: | :----------: | :----------: |
| ![Simulator Screen Recording - iPhone 11 - 2022-05-23 at 15 14 23](https://user-images.githubusercontent.com/65601189/169761809-786fe046-1755-4934-acd3-f1abab4842ca.gif) | ![Simulator Screen Recording - iPhone 11 - 2022-05-23 at 15 15 19](https://user-images.githubusercontent.com/65601189/169755177-4c6504f0-ecc6-4413-aebe-1bf16c73853d.gif) |  용량 부족으로 올라가지 않네요오  |

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #43 
