### PR TITLE
[FIX] DaangnNaviBar setUp() 호출시점 수정

### DIFF
--- a/DaangnMarket/DaangnMarket/Scene/DaangnNaviBar/DaangnNaviBar.swift
+++ b/DaangnMarket/DaangnMarket/Scene/DaangnNaviBar/DaangnNaviBar.swift
@@ -17,9 +17,8 @@ final class DaangnNaviBar: UIView {
     @IBOutlet weak var dropdownImageView: UIImageView!
     @IBOutlet weak var doneButton: UIButton!
     
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        
+    override func awakeFromNib() {
+        setUp()
     }
     
     class func createMyClassView() -> DaangnNaviBar {

--- a/DaangnMarket/DaangnMarket/Scene/Writing/WritingViewController.swift
+++ b/DaangnMarket/DaangnMarket/Scene/Writing/WritingViewController.swift
@@ -46,7 +46,7 @@ class WritingViewController: UIViewController {
     }
     
     // MARK: - setup 메서드
-    func setUp() {
+    private func setUp() {
         
         scrollView.showsVerticalScrollIndicator = false
         scrollView.bounces = false
@@ -59,7 +59,7 @@ class WritingViewController: UIViewController {
         priceTextView.keyboardType = .numberPad
     }
     
-    func configureUI() {
+    private func configureUI() {
 
         [SelectedImageCollectionViewCell.className,
          CameraButtonCollectionViewCell.className].forEach {
@@ -84,7 +84,7 @@ class WritingViewController: UIViewController {
         }
     }
     
-    func setToolBar() {
+    private func setToolBar() {
         
         let keyboardToolBar = UIToolbar(frame: CGRect(x: 0, y: 0, width: view.frame.size.width, height: 40))
         
@@ -98,7 +98,7 @@ class WritingViewController: UIViewController {
         [titleTextView, priceTextView, contentTextView].forEach { $0?.inputAccessoryView = keyboardToolBar }
     }
     
-    func setNavigationBar() {
+    private func setNavigationBar() {
 
         self.navigationController?.navigationBar.isHidden = true
         let daangnNaviBar = DaangnNaviBar.createMyClassView()
@@ -113,9 +113,6 @@ class WritingViewController: UIViewController {
         daangnNaviBar.doneButtonAction = {
             self.dismiss(animated: true, completion: nil)
         }
-        
-        daangnNaviBar.setUp()
-        
     }
 }
 


### PR DESCRIPTION
DaangnNaviBar setUp() 호출시점 수정

## 🌱 작업한 내용

- required init?(coder: NSCoder) 에서 setUp()을 호출해주면 에러가 나는 이유를 짚고,, 호출 시점을 변경해주었습니다

required init? 생성자는 XIB 파일이 nib으로 언아카이빙 되는 시점에 호출되기 때문에 IBOutlet, frame 과 같은 UI관련 객체가 제대로 생성되지 않은 시점

awakeFromNib()은 init을 통해 뷰가 생성되고, IBOutlet 설정까지 끝난 후에 호출되기 때문에 요 메서드 안에서 setUp()을 호출해주면 된답니당

XIB 사용 신고식 거하게 올리네요 ^0^~~
방금 말한거 블로그에도 정리해봤서요

https://teunteun2.tistory.com/11?category=545074

## 📮 관련 이슈

- Resolved: #39 
