### PR TITLE
[FIX] ImagePickerView-NavigationBar 버그 #47

### DIFF
--- a/DaangnMarket/DaangnMarket/Scene/ImagePicker/ImagePickerViewController.storyboard
+++ b/DaangnMarket/DaangnMarket/Scene/ImagePicker/ImagePickerViewController.storyboard
@@ -18,7 +18,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UwV-h4-crk" customClass="DaangnNaviBar" customModule="DaangnMarket" customModuleProvider="target">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UwV-h4-crk">
                                 <rect key="frame" x="0.0" y="44" width="414" height="40"/>
                                 <color key="backgroundColor" name="daangnWhite"/>
                                 <constraints>

--- a/DaangnMarket/DaangnMarket/Scene/ImagePicker/ImagePickerViewController.swift
+++ b/DaangnMarket/DaangnMarket/Scene/ImagePicker/ImagePickerViewController.swift
@@ -71,7 +71,6 @@ class ImagePickerViewController: UIViewController {
             
             self.dismiss(animated: true)
         }
-        daangnNaviBar.setUp()
         
         navigationBarView.addSubview(daangnNaviBar)
     }


### PR DESCRIPTION
## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

NavigationBarView 중복 호출 오류 해결

-  NavigationBarView 중복 호출 오류 해결
- ImagePickerView 내 setUp 메서드 호출 삭제

## 🌱 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- PR Point 1
- PR Point 2

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    imagePicker로 화면 전환    | 
| :-------------: | 
| ![Simulator Screen Recording - iPhone 11 - 2022-05-25 at 00 37 09](https://user-images.githubusercontent.com/65601189/170075902-8363ea5a-5d58-4c3a-8a41-922552a233f2.gif) | 

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #47 
